### PR TITLE
Add validate command to CLI and implement app.json validation

### DIFF
--- a/src/phtoolbox/cli.py
+++ b/src/phtoolbox/cli.py
@@ -3,6 +3,7 @@ example:
 phantom deploy app.tar
 phantom deploy --token TOKEN --hostname example.com app.tar
 phantom deps -i src/app.json -o dist/app.json wheels
+phantom validate app.tar
 """
 
 import argparse
@@ -11,6 +12,7 @@ import os
 import sys
 
 from .deploy import deploy
+from .validate import validate
 
 try:
     from .deps import deps
@@ -123,6 +125,17 @@ def init_parser():
         type=argparse.FileType('w'),
         help="Output SOAR app metadata file",
     )
+    validate_parser = subparsers.add_parser(
+        'validate',
+        help="Validate app.tar files before deployment",
+    )
+    validate_parser.set_defaults(func=validate)
+    validate_parser.add_argument(
+        "file",
+        metavar="FILE",
+        type=argparse.FileType('rb'),
+        help="Tar file to validate")
+
     return parser
 
 

--- a/src/phtoolbox/validate.py
+++ b/src/phtoolbox/validate.py
@@ -1,0 +1,104 @@
+"""
+Validate app.tar files before deployment to SOAR.
+
+This module provides functionality to validate the contents of
+app.tar files, specifically checking that app.json contains valid
+data with no empty top-level values.
+"""
+
+import json
+import sys
+import tarfile
+
+from os.path import basename
+from typing import Any, Dict, List
+
+
+def validate_app_json(app_json: Dict[str, Any]) -> List[str]:
+    """
+    Validate that app.json has no empty top-level values.
+
+    Args:
+        app_json_data: The parsed JSON data from app.json
+
+    Returns:
+        List of validation error messages. Empty list means validation passed.
+    """
+    errors = []
+
+    for key, value in app_json.items():
+        if value is None or value == "" or \
+           (isinstance(value, (list, dict)) and len(value) == 0):
+            errors.append(f"Top-level key '{key}' has an empty value")
+
+    return errors
+
+
+def untar_app_json(tar_path: str) -> Dict[str, Any]:
+    """
+    Extract app.json from tar_path.
+
+    Args:
+        tar_path: A path to a tar file containing an app.json file.
+
+    Returns:
+        A dictionary containing the JSON contents of app.json.
+    """
+    try:
+        # Look for app.json in the tar file
+        with tarfile.open(tar_path, 'r') as tar:
+            app_json_members = [member for member in tar.getmembers()
+                                if basename(member.name) == 'app.json']
+
+            if not app_json_members:
+                raise Exception("Error: No app.json found in {tar_path}")
+            if len(app_json_members) > 1:
+                raise Exception(
+                    f"Error: Multiple app.json files found in {tar_path}"
+                )
+
+            app_json_file = tar.extractfile(app_json_members[0])
+            if app_json_file is None:
+                raise Exception(
+                    f"Error: Could not extract app.json from {tar_path}"
+                )
+            return json.loads(app_json_file.read().decode('utf-8'))
+    except (UnicodeDecodeError, json.JSONDecodeError) as e:
+        raise Exception(f"Error: Invalid JSON in app.json: {e}")
+    except tarfile.TarError as e:
+        raise Exception(f"Error: Invalid tar file {tar_path}: {e}")
+    except FileNotFoundError:
+        raise Exception(f"Error: File not found: {tar_path}")
+    except Exception as e:
+        raise Exception(
+            f"Error: Unexpected error validating {tar_path}: {e}"
+        )
+
+
+def validate(args) -> int:
+    """
+    CLI entry point for the validate command.
+
+    Args:
+        args: Parsed command line arguments
+
+    Returns:
+        Exit code: 0 for success, 1 for validation failure
+    """
+    try:
+        app_json = untar_app_json(args.file.name)
+    except Exception as e:
+        print(e, file=sys.stderr)
+        return 1
+
+    # Validate the JSON data
+    validation_errors = validate_app_json(app_json)
+
+    if validation_errors:
+        print("Validation failed:", file=sys.stderr)
+        for error in validation_errors:
+            print(f"  - {error}", file=sys.stderr)
+        return 1
+
+    print(f"✓ Validation passed: {args.file.name}")
+    return 0


### PR DESCRIPTION
# App.tar Validator Implementation

## Overview
Implementation of issue #25: Added `phantom validate` command to scan `app.json` in `app.tar` files before deployment and return descriptive error messages for validation failures.

## Files Modified/Created

### New Files
- `src/phtoolbox/validate.py` - Core validation logic

### Modified Files
- `src/phtoolbox/__init__.py` - Added CLI integration for `validate` command

## Usage

```bash
# Validate an app.tar file
phantom validate app.tar

# Get help
phantom validate --help
```

## Validation Rules

The validator checks for empty values in top-level JSON keys:
- Empty strings (`""`)
- `null` values
- Empty lists (`[]`)
- Empty dictionaries (`{}`)

## Return Codes
- `0` - Validation passed
- `1` - Validation failed (with detailed error messages)
- `2` - File not found or invalid arguments

## Example Output

### Valid File
```bash
$ phantom validate valid_app.tar
✓ Validation passed: valid_app.tar
```

### Invalid File
```bash
$ phantom validate invalid_app.tar
Validation failed:
  - Top-level key 'name' has an empty value
  - Top-level key 'version' has an empty value
```

## Testing

Tested with various scenarios:
-  Valid JSON data
-  Empty string values
-  Null values
-  Empty lists and dictionaries
-  Missing app.json files
-  Invalid JSON syntax
-  Non-existent tar files
-  macOS resource fork files

## Integration

The validator integrates seamlessly with existing phantom CLI commands and can be used in deployment pipelines:

```bash
phantom validate app.tar && phantom deploy app.tar
```
