### PR TITLE
Fix import error

### DIFF
--- a/src/phtoolbox/__init__.py
+++ b/src/phtoolbox/__init__.py
@@ -16,7 +16,7 @@ from .deploy import deploy
 try:
     from .deps import deps
 except ImportError as ex:
-    def deps(ns, message=str(ex)):
+    def deps(ns, message=str(ex)):  # type: ignore
         '''Allow use of NiceBaseConnector in
         environments that do not support `phtoolbox deps`
 


### PR DESCRIPTION
- Add import protection around `deps` function to allow NiceBaseConnector to be used without `wheel_inspect`

Closes #29